### PR TITLE
[fix]: Replace NavigationStack with NavigationView for iOS 15.2 compa…

### DIFF
--- a/EasyCommerce/Views/Auth/LoginView.swift
+++ b/EasyCommerce/Views/Auth/LoginView.swift
@@ -20,7 +20,7 @@ struct LoginView: View {
     }
 
     var body: some View {
-        NavigationStack {
+        NavigationView {
             ScrollView {
                 VStack(spacing: AppTheme.Spacing.xxl) {
                     // Logo & Welcome

--- a/EasyCommerce/Views/Auth/SignUpView.swift
+++ b/EasyCommerce/Views/Auth/SignUpView.swift
@@ -38,7 +38,7 @@ struct SignUpView: View {
     }
 
     var body: some View {
-        NavigationStack {
+        NavigationView {
             ScrollView {
                 VStack(spacing: AppTheme.Spacing.xl) {
                     // Header

--- a/EasyCommerce/Views/Cart/CartView.swift
+++ b/EasyCommerce/Views/Cart/CartView.swift
@@ -12,7 +12,7 @@ struct CartView: View {
     @State private var showCheckout: Bool = false
 
     var body: some View {
-        NavigationStack {
+        NavigationView {
             Group {
                 if cartManager.isEmpty {
                     emptyCartView

--- a/EasyCommerce/Views/Categories/CategoriesView.swift
+++ b/EasyCommerce/Views/Categories/CategoriesView.swift
@@ -17,7 +17,7 @@ struct CategoriesView: View {
     ]
 
     var body: some View {
-        NavigationStack {
+        NavigationView {
             ScrollView {
                 if viewModel.categories.isEmpty {
                     categoriesSkeleton

--- a/EasyCommerce/Views/Components/ProductReviews.swift
+++ b/EasyCommerce/Views/Components/ProductReviews.swift
@@ -323,7 +323,7 @@ struct AllReviewsView: View {
     }
 
     var body: some View {
-        NavigationStack {
+        NavigationView {
             ScrollView {
                 VStack(spacing: AppTheme.Spacing.lg) {
                     // Rating Summary

--- a/EasyCommerce/Views/Home/HomeView.swift
+++ b/EasyCommerce/Views/Home/HomeView.swift
@@ -30,7 +30,7 @@ struct HomeView: View {
     }
 
     var body: some View {
-        NavigationStack {
+        NavigationView {
             ScrollView {
                 VStack(spacing: 0) {
                     // Search Bar

--- a/EasyCommerce/Views/Orders/OrderHistoryView.swift
+++ b/EasyCommerce/Views/Orders/OrderHistoryView.swift
@@ -26,7 +26,7 @@ struct OrderHistoryView: View {
     }
 
     var body: some View {
-        NavigationStack {
+        NavigationView {
             VStack(spacing: 0) {
                 // Filter Tabs
                 filterTabs

--- a/EasyCommerce/Views/Product/ProductDetailView.swift
+++ b/EasyCommerce/Views/Product/ProductDetailView.swift
@@ -420,7 +420,7 @@ struct ShareSheet: UIViewControllerRepresentable {
 
 struct ProductDetailView_Previews: PreviewProvider {
     static var previews: some View {
-        NavigationStack {
+        NavigationView {
             ProductDetailView(product: ProductListingViewModel.sampleProduct)
                 .environmentObject(CartManager.shared)
                 .environmentObject(WishlistManager.shared)

--- a/EasyCommerce/Views/Profile/ProfileView.swift
+++ b/EasyCommerce/Views/Profile/ProfileView.swift
@@ -19,7 +19,7 @@ struct ProfileView: View {
     @ObservedObject private var currencyFormatter = CurrencyFormatter.shared
 
     var body: some View {
-        NavigationStack {
+        NavigationView {
             List {
                 // User Section
                 userSection

--- a/EasyCommerce/Views/Search/AdvancedSearchView.swift
+++ b/EasyCommerce/Views/Search/AdvancedSearchView.swift
@@ -92,7 +92,7 @@ struct AdvancedSearchView: View {
     }
 
     var body: some View {
-        NavigationStack {
+        NavigationView {
             VStack(spacing: 0) {
                 // Search Header
                 searchHeader
@@ -406,7 +406,7 @@ struct FilterSheet: View {
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
-        NavigationStack {
+        NavigationView {
             List {
                 // Price Range
                 Section("Price Range") {

--- a/EasyCommerce/Views/Wishlist/WishlistView.swift
+++ b/EasyCommerce/Views/Wishlist/WishlistView.swift
@@ -17,7 +17,7 @@ struct WishlistView: View {
     ]
 
     var body: some View {
-        NavigationStack {
+        NavigationView {
             Group {
                 if wishlistManager.isEmpty {
                     emptyView


### PR DESCRIPTION
- NavigationStack is only available in iOS 16.0+
- Replaced all instances with NavigationView for backward compatibility
- Affects 11 view files across the app
- Maintains same functionality with iOS 15.2+ support