### PR TITLE
[fix]: Fix iOS 15.2 backward compatibility issues

### DIFF
--- a/EasyCommerce/Models/Category.swift
+++ b/EasyCommerce/Models/Category.swift
@@ -9,5 +9,9 @@ import Foundation
 
 struct Category: Identifiable, Codable, Hashable{
     let id = UUID().uuidString
-    let name:String
+    let name: String
+
+    enum CodingKeys: String, CodingKey {
+        case name
+    }
 }

--- a/EasyCommerce/Models/Rating.swift
+++ b/EasyCommerce/Models/Rating.swift
@@ -11,4 +11,9 @@ struct Rating: Identifiable, Codable, Hashable {
     let id = UUID().uuidString
     let rate: Double
     let count: Int
+
+    enum CodingKeys: String, CodingKey {
+        case rate
+        case count
+    }
 }

--- a/EasyCommerce/Views/Profile/ProfileView.swift
+++ b/EasyCommerce/Views/Profile/ProfileView.swift
@@ -356,13 +356,13 @@ struct RecentlyViewedView: View {
         .navigationTitle("Recently Viewed")
         .navigationBarTitleDisplayMode(.large)
         .toolbar {
-            if !recentlyViewedManager.items.isEmpty {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button("Clear") {
-                        recentlyViewedManager.clear()
-                    }
-                    .foregroundColor(AppTheme.Colors.primaryFallback)
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Clear") {
+                    recentlyViewedManager.clear()
                 }
+                .foregroundColor(AppTheme.Colors.primaryFallback)
+                .opacity(recentlyViewedManager.items.isEmpty ? 0 : 1)
+                .disabled(recentlyViewedManager.items.isEmpty)
             }
         }
     }


### PR DESCRIPTION
1. ProfileView.swift - Fixed toolbar conditional content issue
   - Replaced iOS 16+ conditional toolbar with iOS 15 compatible approach
   - Button now uses opacity and disabled state instead of conditional rendering

2. Rating.swift - Fixed Codable decode warning
   - Added CodingKeys enum to exclude 'id' from decoding
   - ID is generated locally, not from API response

3. Category.swift - Fixed Codable decode warning
   - Added CodingKeys enum to exclude 'id' from decoding
   - ID is generated locally, not from API response

All changes maintain backward compatibility with iOS 15.2